### PR TITLE
Adding Xamarin.Essentials.Interfaces

### DIFF
--- a/Xamarin.Forms/BlankApp/BlankApp.Android/BlankApp.Android.csproj
+++ b/Xamarin.Forms/BlankApp/BlankApp.Android/BlankApp.Android.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Essentials.Interfaces" Version="1.5.2" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />

--- a/Xamarin.Forms/BlankApp/BlankApp.Android/LinkerSettings.xml
+++ b/Xamarin.Forms/BlankApp/BlankApp.Android/LinkerSettings.xml
@@ -4,6 +4,11 @@
       For more information see the docs on creating custom Linker Settings
       https://docs.microsoft.com/en-us/xamarin/cross-platform/deploy-test/linker
   -->
+  <assembly fullname="Essential.Interfaces">
+    <type fullname="Xamarin.Essentials.Implementation.AppInfoImplementation">
+      <method name=".ctor" />
+    </type>
+  </assembly>
 
   <assembly fullname="Prism" />
   <assembly fullname="Prism.Forms" />

--- a/Xamarin.Forms/BlankApp/BlankApp.Android/MainActivity.cs
+++ b/Xamarin.Forms/BlankApp/BlankApp.Android/MainActivity.cs
@@ -9,15 +9,23 @@ namespace BlankApp.Droid
     [Activity(Label = "BlankApp", Icon = "@mipmap/ic_launcher", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
-        protected override void OnCreate(Bundle bundle)
+        protected override void OnCreate(Bundle savedInstanceState)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
 
-            base.OnCreate(bundle);
+            base.OnCreate(savedInstanceState);
 
-            global::Xamarin.Forms.Forms.Init(this, bundle);
+            Xamarin.Essentials.Platform.Init(this, savedInstanceState);
+            global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
             LoadApplication(new App(new AndroidInitializer()));
+        }
+
+        public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Android.Content.PM.Permission[] grantResults)
+        {
+            Xamarin.Essentials.Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+
+            base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 

--- a/Xamarin.Forms/BlankApp/BlankApp.UWP/BlankApp.UWP.csproj
+++ b/Xamarin.Forms/BlankApp/BlankApp.UWP/BlankApp.UWP.csproj
@@ -134,6 +134,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Essentials.Interfaces" Version="1.5.2" />
     <PackageReference Condition=" '$(Container)' == 'DryIoc' " Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
     <PackageReference Condition=" '$(Container)' == 'Unity' " Include="Prism.Unity.Forms" Version="7.2.0.1422" />
   </ItemGroup>

--- a/Xamarin.Forms/BlankApp/BlankApp.iOS/BlankApp.iOS.csproj
+++ b/Xamarin.Forms/BlankApp/BlankApp.iOS/BlankApp.iOS.csproj
@@ -194,6 +194,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Essentials.Interfaces" Version="1.5.2" />
     <PackageReference Condition=" '$(Container)' == 'DryIoc' " Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
     <PackageReference Condition=" '$(Container)' == 'Unity' " Include="Prism.Unity.Forms" Version="7.2.0.1422" />
   </ItemGroup>

--- a/Xamarin.Forms/BlankApp/BlankApp.iOS/LinkerSettings.xml
+++ b/Xamarin.Forms/BlankApp/BlankApp.iOS/LinkerSettings.xml
@@ -4,6 +4,11 @@
       For more information see the docs on creating custom Linker Settings
       https://docs.microsoft.com/en-us/xamarin/cross-platform/deploy-test/linker
   -->
+  <assembly fullname="Essential.Interfaces">
+    <type fullname="Xamarin.Essentials.Implementation.AppInfoImplementation">
+      <method name=".ctor" />
+    </type>
+  </assembly>
 
   <assembly fullname="Prism" />
   <assembly fullname="Prism.Forms" />

--- a/Xamarin.Forms/BlankApp/BlankApp/App.xaml.cs
+++ b/Xamarin.Forms/BlankApp/BlankApp/App.xaml.cs
@@ -1,7 +1,9 @@
-﻿using Prism;
+using Prism;
 using Prism.Ioc;
 using BlankApp.ViewModels;
 using BlankApp.Views;
+using Xamarin.Essentials.Interfaces;
+using Xamarin.Essentials.Implementation;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -28,6 +30,8 @@ namespace BlankApp
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {
+            containerRegistry.RegisterSingleton<IAppInfo, AppInfoImplementation>();
+
             containerRegistry.RegisterForNavigation<NavigationPage>();
             containerRegistry.RegisterForNavigation<MainPage, MainPageViewModel>();
         }

--- a/Xamarin.Forms/BlankApp/BlankApp/BlankApp.csproj
+++ b/Xamarin.Forms/BlankApp/BlankApp/BlankApp.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Essentials.Interfaces" Version="1.5.2" />
     <PackageReference Condition=" '$(Container)' == 'DryIoc' " Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
     <PackageReference Condition=" '$(Container)' == 'Unity' " Include="Prism.Unity.Forms" Version="7.2.0.1422" />
   </ItemGroup>


### PR DESCRIPTION
# Description

As the Xamarin.Forms templates are now starting use Xamarin.Essentials as a base dependency, we're updating the templates to give developers the same functionality... only done correctly with Interfaces because @rdavisau knew testable code is important... cheers mate